### PR TITLE
Handle unnamespaced attributes in schema export

### DIFF
--- a/src/cli/queries.clj
+++ b/src/cli/queries.clj
@@ -22,7 +22,8 @@
               :where [?e :db/ident ?element]]
             db)
        (map first)
-       (filter #(re-matches #"^(db.schema|(?!db))(?!fressian).+" (-> % :db/ident namespace)))))
+       (filter #(re-matches #"^(db.schema|(?!db))(?!fressian).+" (or (-> % :db/ident namespace)
+                                                                     "")))))
 
 (defn attr-tx-instances [db a]
   (->> (d/q '[:find ?txInstant


### PR DESCRIPTION
`cli.queries/schema` assumes that all attributes have a namespace. In my case, I have a single unnamespaced attribute (`:is-draft`) which causes the call to [`re-matches`](https://github.com/JarrodCTaylor/schema-cartographer/blob/master/src/cli/queries.clj#L25) to stacktrace with a null pointer exception.

