### PR TITLE
Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ The annotations used by the application are:
 ``` clojure
 (def annotation-schema-tx [{:db/ident :cartographer/entity
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an entity-grouping namespace in the application."}
                            {:db/ident :cartographer/enumeration
+                            :db/unique :db.unique/identity
                             :db/valueType :db.type/keyword
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an enumeration-grouping namespace in the application."}

--- a/resources/complete_example_schema.clj
+++ b/resources/complete_example_schema.clj
@@ -4,10 +4,12 @@
 
 (def annotation-schema-tx [{:db/ident :cartographer/entity
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an entity-grouping namespace in the application."}
                            {:db/ident :cartographer/enumeration
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an enumeration-grouping namespace in the application."}
                            {:db/ident :cartographer/deprecated?

--- a/src/cli/core.clj
+++ b/src/cli/core.clj
@@ -1,5 +1,6 @@
 (ns cli.core
   (:require
+    [clojure.edn :as edn]
     [clojure.tools.cli :refer [parse-opts]]
     [clojure.string :as str]
     [clojure.pprint :as pp]
@@ -19,13 +20,17 @@
 (def client (memoize (fn [region system]
                        (d/client (datomic-arg-map region system)))))
 
-(defn db-conn [region system db-name]
-  (d/connect (client region system) {:db-name db-name}))
+(defn db-conn [client-file region system db-name]
+  (let [client (if client-file
+                 (-> client-file slurp edn/read-string d/client)
+                 (client region system))]
+    (d/connect client {:db-name db-name})))
 ; endregion
 
 (def cli-options
-  [["-r" "--region REGION" "Region where Datomic cloud is located"]
-   ["-s" "--system SYSTEM" "Datomic cloud system name"]
+  [["-c" "--client-file CLIENT-FILE" "Filename containing edn client args"]
+   ["-r" "--region REGION" "Region where Datomic cloud is located. Deprecated, see --client-file."]
+   ["-s" "--system SYSTEM" "Datomic cloud system name. Deprecated, see --client-file."]
    ["-d" "--db DATABASE" "Database Name"]
    ["-o" "--output FILE" "Write schema edn to FILE"]
    ["-a" "--audit" "Audit schema annotations and log gaps. Boolean"]
@@ -42,9 +47,8 @@
         "clojure -m clj.core -r [region] -s [system] -d [database] --audit"]
        (str/join \newline)))
 
-(defn save-schema-edn [region system db-name schema-file-name]
-  (let [conn (db-conn region system db-name)
-        raw-schema (queries/schema (d/db conn))
+(defn save-schema-edn [conn schema-file-name]
+  (let [raw-schema (queries/schema (d/db conn))
         schema-data (data-map raw-schema)
         output-location (str "doc/" schema-file-name ".edn")]
     (spit output-location (with-out-str (pp/pprint schema-data)))
@@ -52,10 +56,10 @@
 
 (defn -main [& args]
   (let [{:keys [summary]
-         {:keys [help region system db output audit]} :options} (parse-opts args cli-options)]
+         {:keys [help region client-file system db output audit]} :options} (parse-opts args cli-options)]
     (cond
       (or help
           (and (not audit) (nil? output))
-          (some nil? [region system db])) (println (usage summary))
-      audit (log-schema-audit (db-conn region system db))
-      :else (save-schema-edn region system db output))))
+          (not (and db (or client-file (and region system))))) (println (usage summary))
+      audit (log-schema-audit (db-conn client-file region system db))
+      :else (save-schema-edn (db-conn client-file region system db) output))))


### PR DESCRIPTION
Parsing command line args into maps one key at a time is fragile, and loses the benefit of Clojure's maps being open, e.g. every enhancement to Datomic client maps will be unavailable in cartographer until a parallel change is made here. I proposed adding a single command line property that names an edn file.

Separately, cartographer entities and enumerations should be unique identity. It would not make sense to have two with the same keyword, and it facilitates talking about the entities in later transactions.

Note that these changes are untested. :-) 