### PR TITLE
:cartographer/entity and :cartographer/enumeration should be unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,12 @@ The annotations used by the application are:
 ``` clojure
 (def annotation-schema-tx [{:db/ident :cartographer/entity
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an entity-grouping namespace in the application."}
                            {:db/ident :cartographer/enumeration
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an enumeration-grouping namespace in the application."}
                            {:db/ident :cartographer/deprecated?

--- a/resources/complete_example_schema.clj
+++ b/resources/complete_example_schema.clj
@@ -4,10 +4,12 @@
 
 (def annotation-schema-tx [{:db/ident :cartographer/entity
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an entity-grouping namespace in the application."}
                            {:db/ident :cartographer/enumeration
                             :db/valueType :db.type/keyword
+                            :db/unique :db.unique/identity
                             :db/cardinality :db.cardinality/one
                             :db/doc "Creating an entity with this attr will cause its value to be considered an enumeration-grouping namespace in the application."}
                            {:db/ident :cartographer/deprecated?

--- a/src/client/routes/index/events.cljs
+++ b/src/client/routes/index/events.cljs
@@ -195,10 +195,12 @@
   (fn [{:keys [db]} [_ _]]
     (let [annotation-attrs [{:db/ident :cartographer/entity
                              :db/valueType :db.type/keyword
+                             :db/unique :db.unique/identity
                              :db/cardinality :db.cardinality/one
                              :db/doc "Creating an entity with this attr will cause its value to be considered an entity-grouping namespace in the application."}
                             {:db/ident :cartographer/enumeration
                              :db/valueType :db.type/keyword
+                             :db/unique :db.unique/identity
                              :db/cardinality :db.cardinality/one
                              :db/doc "Creating an entity with this attr will cause its value to be considered an enumeration-grouping namespace in the application."}
                             {:db/ident :cartographer/deprecated?


### PR DESCRIPTION
This *COULD* be a breaking change. If `:cartographer/entity`s or `:cartographer/enumeration`s had previously been transacted more than once. 