### PR TITLE
avoid throwing exceptions when namespace function called with nil

### DIFF
--- a/src/schema_cartographer/explorer.clj
+++ b/src/schema_cartographer/explorer.clj
@@ -34,7 +34,7 @@
             (when (= 0 (mod counter 100000))
               (println " --" (format "%,d" counter) "processed"))
             {:counter (inc counter)
-             :response (set/union response #{(or (namespace kws) "unnamespaced")})})
+             :response (set/union response #{(or (and kws (namespace kws)) "unnamespaced")})})
           {:counter 0 :response #{}}
           (if ref-search-limit
             (take ref-search-limit idents)
@@ -45,7 +45,7 @@
             (when (= 0 (mod counter 100000))
               (println " --" (format "%,d" counter) "processed"))
             {:counter (inc counter)
-             :response (set/union response (disj (set (map #(or (namespace %) "unnamespaced") kws)) "db"))})
+             :response (set/union response (disj (set (map #(or (and kws (namespace %)) "unnamespaced") kws)) "db"))})
           {:counter 0 :response #{}}
           (if ref-search-limit
             (take ref-search-limit keys)


### PR DESCRIPTION
When the null value supplied to the `namespace` function execution doesn't hit the second parameter to `or`, namely string "unnamespaced" because it throws Exception `ClassCastException` for null.

Could be fixed by wrapping in try-catch block, but probably using `and` is a bit simpler.

